### PR TITLE
Highlight Active Edges

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -17,13 +17,15 @@ const App = () => {
   const [query, setQuery] = useState(null);
   const [activeTypeIDs, setActiveTypeIDs] = useState(null);
   const [activeFieldIDs, setActiveFieldIDs] = useState(null);
+  const [activeEdgeIDs, setActiveEdgeIDs] = useState(null);
 
   // If the user executes a query, update the active ID's
   useEffect(() => {
     if (query === null) return;
-    const {activeTypeIDs, activeFieldIDs} = getActivesFromQuery(query, vSchema);
+    const {activeTypeIDs, activeFieldIDs, activeEdgeIDs} = getActivesFromQuery(query, vSchema);
     setActiveTypeIDs(activeTypeIDs);
     setActiveFieldIDs(activeFieldIDs);
+    setActiveEdgeIDs(activeEdgeIDs);
   }, [query]);
 
   return (
@@ -40,6 +42,7 @@ const App = () => {
           vSchema={vSchema}
           activeTypeIDs={activeTypeIDs}
           activeFieldIDs={activeFieldIDs}
+          activeEdgeIDs={activeEdgeIDs}
         />
       </section>
     </main>

--- a/client/src/components/Visualizer.jsx
+++ b/client/src/components/Visualizer.jsx
@@ -21,7 +21,7 @@ const nodeTypes = {
   typeNode: TypeNode,
 };
 
-const Visualizer = ({ vSchema, activeTypeIDs, activeFieldIDs }) => {
+const Visualizer = ({ vSchema, activeTypeIDs, activeFieldIDs, activeEdgeIDs}) => {
   // State management for a controlled React Flow
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -87,6 +87,17 @@ const Visualizer = ({ vSchema, activeTypeIDs, activeFieldIDs }) => {
     };
     generateGraph();
   }, [vSchema, nodesInitialized]);
+
+  useEffect(() => {
+    setEdges(prevEdges => {
+      return prevEdges.map(edge => {
+        return {
+          ...edge,
+          style: {stroke: activeEdgeIDs.has(edge.id) ? 'magenta' : 'cornflowerblue'}
+        }
+      });
+    });
+  }, [activeEdgeIDs]);
 
   return (
     // React Flow instance needs a container that has explicit width and height

--- a/client/src/components/Visualizer.jsx
+++ b/client/src/components/Visualizer.jsx
@@ -93,7 +93,12 @@ const Visualizer = ({ vSchema, activeTypeIDs, activeFieldIDs, activeEdgeIDs}) =>
       return prevEdges.map(edge => {
         return {
           ...edge,
-          style: {stroke: activeEdgeIDs.has(edge.id) ? 'magenta' : 'cornflowerblue'}
+          markerEnd: {
+            ...edge.markerEnd,
+              color: activeEdgeIDs.has(edge.id) ? 'magenta' : 'cornflowerblue'
+          },
+          style: {stroke: activeEdgeIDs.has(edge.id) ? 'magenta' : 'cornflowerblue'},
+          zIndex: activeEdgeIDs.has(edge.id) ? 2 : -2
         }
       });
     });

--- a/client/src/utils/getActivesFromQuery.js
+++ b/client/src/utils/getActivesFromQuery.js
@@ -13,6 +13,7 @@ const getActivesFromQuery = (queryString, vSchema) => {
 
   const activeTypeIDs = new Set();
   const activeFieldIDs = new Set();
+  const activeEdgeIDs = new Set();
 
   // The particular name that corresponds to the Query/Root Type in the vSchema
   // (The name is arbitrary)
@@ -28,6 +29,7 @@ const getActivesFromQuery = (queryString, vSchema) => {
     if (gqlSelection.selectionSet) {
       const vSchemaField = vSchemaType.fields.find(field => field.fieldName === gqlSelection.name.value);
       const vSchemaNextType = vSchemaTypes.find(type => type.name === vSchemaField.relationship);
+      activeEdgeIDs.add(`${vSchemaType.name}/${gqlSelection.name.value}-${vSchemaNextType.name}`);
       for (const selection of gqlSelection.selectionSet.selections) {
         addActives(vSchemaNextType, selection);
       }
@@ -41,7 +43,8 @@ const getActivesFromQuery = (queryString, vSchema) => {
   }
   return {
     activeTypeIDs,
-    activeFieldIDs
+    activeFieldIDs,
+    activeEdgeIDs
   };
 }
 


### PR DESCRIPTION
Update getActivesFromQuery algorithm to account for edges. 
Pull edge management state to top level. 
Pass down and listen accordingly.
Conditionally render edges according to active status.