### PR TITLE
Rudimentary Dynamic Hide and Show of Relevant Nodes and Edges

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,9 +29,9 @@ const App = () => {
     setActiveEdgeIDs(activeEdgeIDs);
   }, [query]);
 
-  console.log('ATIDs: ', activeTypeIDs );
-  console.log('AFIDs: ', activeFieldIDs );
-  console.log('AEIDs: ', activeEdgeIDs );
+  // console.log('ATIDs: ', activeTypeIDs );
+  // console.log('AFIDs: ', activeFieldIDs );
+  // console.log('AEIDs: ', activeEdgeIDs );
 
   return (
     <main>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,7 @@ const App = () => {
   const [activeTypeIDs, setActiveTypeIDs] = useState(null);
   const [activeFieldIDs, setActiveFieldIDs] = useState(null);
   const [activeEdgeIDs, setActiveEdgeIDs] = useState(null);
+  const [displayMode, setDisplayMode] = useState('activeOnly');
 
   // If the user executes a query, update the active ID's
   useEffect(() => {
@@ -27,6 +28,10 @@ const App = () => {
     setActiveFieldIDs(activeFieldIDs);
     setActiveEdgeIDs(activeEdgeIDs);
   }, [query]);
+
+  console.log('ATIDs: ', activeTypeIDs );
+  console.log('AFIDs: ', activeFieldIDs );
+  console.log('AEIDs: ', activeEdgeIDs );
 
   return (
     <main>
@@ -43,6 +48,7 @@ const App = () => {
           activeTypeIDs={activeTypeIDs}
           activeFieldIDs={activeFieldIDs}
           activeEdgeIDs={activeEdgeIDs}
+          displayMode={displayMode}
         />
       </section>
     </main>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -43,10 +43,10 @@ const App = () => {
   return (
     <main>
         <Split className='split' sizes={[25,75]} style={{height: "100vh", width: "100vw"}}>
-          <div class="seg-holder">
+          <div className="seg-holder">
             <Editor id='editor' schema={schema} endpoint={endpoint} setQuery={setQuery} ></Editor>
           </div>
-          <div class="seg-holder">
+          <div className="seg-holder">
             <section className="visualizer-section">
               <Endpoint
                 endpoint={endpoint}

--- a/client/src/Editor.jsx
+++ b/client/src/Editor.jsx
@@ -4,6 +4,7 @@ import { initializeMode } from 'monaco-graphql/esm/initializeMode';
 import { createGraphiQLFetcher } from '@graphiql/toolkit';
 import * as JSONC from 'jsonc-parser';
 import { debounce } from './utils/debounce';
+import validateBrackets from './utils/validateBrackets';
 
 // description that is displayed in request pane above actual code
 // indicate to the user what commands are available and defined
@@ -87,6 +88,12 @@ export default function Editor({schema, endpoint, setQuery}) {
     const variables = editor.getModel(Uri.file('variables.json')).getValue();
     // grab the operations from the operations pane
     const operations = editor.getModel(Uri.file('operation.graphql')).getValue();
+    if (!validateBrackets(operations)) {
+      alert('Invalid brackets');
+      // refactor later with better overall error handling when we decide the route to take
+      // obviously we don't want to alert, but simply show a message in the appropriate place
+      return;
+    };
     // update active ID's
     setQuery(operations);
     // create reference to the results pane

--- a/client/src/components/Field.jsx
+++ b/client/src/components/Field.jsx
@@ -50,7 +50,7 @@ const Field = ({ typeName, fieldName, returnType, updateEdge, relationship, acti
         },
         // animated: true,
         style: { stroke: 'cornflowerblue' },
-        hidden: displayMode === 'activeOnly'
+        hidden: false
       });
     }
   }, []);

--- a/client/src/components/Field.jsx
+++ b/client/src/components/Field.jsx
@@ -1,6 +1,6 @@
 import React, { memo, useEffect, useState } from 'react';
 import { Handle } from 'reactflow';
-import { MarkerType, useNodes, useUpdateNodeInternals } from 'reactflow';
+import { MarkerType, useNodes, useUpdateNodeInternals, useStoreApi } from 'reactflow';
 
 
 const field = {
@@ -20,16 +20,19 @@ const fieldData = {
   gap: 10,
 };
 
-const Field = ({ typeName, fieldName, returnType, updateEdge, relationship, active }) => {
+const Field = ({ typeName, fieldName, returnType, updateEdge, relationship, active, displayMode }) => {
   const nodes = useNodes();
   const updateNodeInternals = useUpdateNodeInternals();
   const [handlePosition, setHandlePosition] = useState('right');
+  const store = useStoreApi();
+
 
   useEffect(() => {
     // In vSchema:
     // 'Relationship' is a key on a field object that only exists if that field points to a type.
     // Its value corresponds 1:1 to the object type name and its node's id
-    if (relationship) {
+    if (relationship &&
+      !store.getState().edges.some(edge => edge.id === `${typeName}/${fieldName}-${relationship}`)) {
       const targetType = relationship;
       updateEdge({
         id: `${typeName}/${fieldName}-${targetType}`,
@@ -47,6 +50,7 @@ const Field = ({ typeName, fieldName, returnType, updateEdge, relationship, acti
         },
         // animated: true,
         style: { stroke: 'cornflowerblue' },
+        hidden: displayMode === 'activeOnly'
       });
     }
   }, []);

--- a/client/src/components/ToggleSwitch.jsx
+++ b/client/src/components/ToggleSwitch.jsx
@@ -19,7 +19,7 @@ export function ToggleSwitch({
             checked={isChecked}
             onChange={(e) => handleChange(e)}
           />
-          <span className="slider round"></span>
+          <span className="toggle-slider round"></span>
         </label>
         <p className="toggle-switch__label-right">{labelRight}</p>
       </div>

--- a/client/src/components/TypeNode.jsx
+++ b/client/src/components/TypeNode.jsx
@@ -25,7 +25,7 @@ const typeHeading = {
 };
 
 const TypeNode = ({ data }) => {
-  const { typeName, fields, updateEdge, active, activeFieldIDs} =  data;
+  const { typeName, fields, updateEdge, active, activeFieldIDs, displayMode} =  data;
   const [fieldElements, setFieldElements] = useState();
 
   // Any time the active field ID's change, remap the fields
@@ -40,6 +40,7 @@ const TypeNode = ({ data }) => {
         updateEdge={updateEdge}
         relationship={field.relationship}
         active={activeFieldIDs?.has(`${typeName}/${field.fieldName}`) ? true : false}
+        displayMode={displayMode}
       />
     )));
   }, [activeFieldIDs]);

--- a/client/src/components/Visualizer.jsx
+++ b/client/src/components/Visualizer.jsx
@@ -177,7 +177,6 @@ const Visualizer = ({
         selectionOnDrag={true}
         selectionMode={SelectionMode.Partial}
         nodeTypes={nodeTypes}
-        fitView={true}
         panOnScroll={true}
         zoom={1}
         minZoom={0.1}

--- a/client/src/components/Visualizer.jsx
+++ b/client/src/components/Visualizer.jsx
@@ -97,12 +97,9 @@ const Visualizer = ({ vSchema, activeTypeIDs, activeFieldIDs, activeEdgeIDs, dis
 
   // Whenever the active edge ID's change, update the edges' properties to reflect the changes
   useEffect(() => {
-    console.log('HERE')
-    console.log('edges: ', edges);
     setEdges(prevEdges => {
       return prevEdges.map(edge => {
         const isActive = activeEdgeIDs.has(edge.id);
-        console.log('edge: ', edge, 'isActive: ', isActive);
         return {
           ...edge,
           markerEnd: {
@@ -115,7 +112,7 @@ const Visualizer = ({ vSchema, activeTypeIDs, activeFieldIDs, activeEdgeIDs, dis
         }
       });
     });
-  }, [activeEdgeIDs]);
+  }, [activeEdgeIDs, displayMode]);
 
   return (
     // React Flow instance needs a container that has explicit width and height

--- a/client/src/styles/ToggleSwitch.css
+++ b/client/src/styles/ToggleSwitch.css
@@ -42,7 +42,7 @@
 
 .toggle-switch__switch input {display:none;}
 
-.slider {
+.toggle-slider {
   position: absolute;
   cursor: pointer;
   top: 0;
@@ -54,7 +54,7 @@
   transition: .4s;
 }
 
-.slider:before {
+.toggle-slider:before {
   position: absolute;
   content: "";
   height: 26px;
@@ -68,21 +68,20 @@
   border: 1px gray solid;
 }
 
-input:checked + .slider {
+input:checked + .toggle-slider {
   background-color: #bbb;
 }
 
-input:checked + .slider:before {
+input:checked + .toggle-slider:before {
   -webkit-transform: translateX(16px);
   -ms-transform: translateX(16px);
   transform: translateX(16px) translateY(12px);
 }
 
 /* Rounded sliders */
-.slider.round {
+.toggle-slider.round {
   border-radius: 34px;
 }
 
-.slider.round:before {
+.toggle-slider.round:before {
   border-radius: 50%;}
-  

--- a/client/src/utils/validateBrackets.js
+++ b/client/src/utils/validateBrackets.js
@@ -1,0 +1,28 @@
+// Check if all brackets are properly closed
+export default function validateBrackets(code) {
+  // Initialize a stack to keep track of opening brackets
+  const stack = [];
+
+  // Loop through each character in the code
+  for (let i = 0; i < code.length; i++) {
+    const char = code.charAt(i);
+
+    // If the character is an opening bracket, push it onto the stack
+    if (char === '(' || char === '[' || char === '{') {
+      stack.push(char);
+    }
+
+    // If the character is a closing bracket, pop the top of the stack and check if it matches
+    else if (char === ')' || char === ']' || char === '}') {
+      const top = stack.pop();
+      if ((char === ')' && top !== '(') ||
+          (char === ']' && top !== '[') ||
+          (char === '}' && top !== '{')) {
+        // There is an unmatched closing bracket
+        return false;
+      }
+    }
+  }
+  // If the stack is not empty, there are unmatched opening brackets
+  return stack.length === 0;
+}


### PR DESCRIPTION
- Implement non-regraphed rudimentary hide and show of Types and Edges based on active statuses.
- Handle user error of invalid brackets.
- Rename 'class' to 'className' for certain jsx elements in the Splits.
- Add more specificity to .slider (renamed to .toggle-slider) in all appropriate places to get rid of conflict with the Monaco editor sliders.

TODO: Add regraph functionality such that when elements are hidden and shown, the spacing appropriately updates