### PR TITLE
menu-and-node collapsibility

### DIFF
--- a/assets/down-arrow-svgrepo-com.svg
+++ b/assets/down-arrow-svgrepo-com.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" height="800px" width="800px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 330 330" xml:space="preserve">
+<path id="XMLID_225_" d="M325.607,79.393c-5.857-5.857-15.355-5.858-21.213,0.001l-139.39,139.393L25.607,79.393
+	c-5.857-5.857-15.355-5.858-21.213,0.001c-5.858,5.858-5.858,15.355,0,21.213l150.004,150c2.813,2.813,6.628,4.393,10.606,4.393
+	s7.794-1.581,10.606-4.394l149.996-150C331.465,94.749,331.465,85.251,325.607,79.393z"/>
+</svg>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@tisoap/react-flow-smart-edge": "^3.0.0",
         "axios": "^0.26.0",
         "elkjs": "^0.8.2",
+        "framer-motion": "^6.3.3",
         "graphql": "^16.6.0",
         "graphql-request": "^5.2.0",
         "graphql-tag": "^2.12.6",
@@ -436,6 +437,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "node_modules/@graphiql/toolkit": {
       "version": "0.8.2",
@@ -1526,6 +1542,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.3.3.tgz",
+      "integrity": "sha512-wo0dCnoq5vn4L8YVOPO9W54dliH78vDaX0Lj+bSPUys6Nt5QaehrS3uaYa0q5eVeikUgtTjz070UhQ94thI5Sw==",
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1640,6 +1683,11 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.5.tgz",
       "integrity": "sha512-G7HLD+WKcrOyJP5VQwYZNC3Z6FcQ7YYjEFiFoIj8PfEr73mu421o8B1N5DKUcc8K37EsJ2XXWA8DtrDz/2dReg=="
+    },
+    "node_modules/hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "node_modules/is-core-module": {
       "version": "2.8.1",
@@ -1860,6 +1908,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
@@ -2048,6 +2107,15 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.6.5.tgz",
       "integrity": "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw=="
+    },
+    "node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -2500,6 +2568,21 @@
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "optional": true,
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "optional": true
     },
     "@graphiql/toolkit": {
       "version": "0.8.2",
@@ -3257,6 +3340,27 @@
         "mime-types": "^2.1.12"
       }
     },
+    "framer-motion": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.3.3.tgz",
+      "integrity": "sha512-wo0dCnoq5vn4L8YVOPO9W54dliH78vDaX0Lj+bSPUys6Nt5QaehrS3uaYa0q5eVeikUgtTjz070UhQ94thI5Sw==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3334,6 +3438,11 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.5.tgz",
       "integrity": "sha512-G7HLD+WKcrOyJP5VQwYZNC3Z6FcQ7YYjEFiFoIj8PfEr73mu421o8B1N5DKUcc8K37EsJ2XXWA8DtrDz/2dReg=="
+    },
+    "hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "is-core-module": {
       "version": "2.8.1",
@@ -3483,6 +3592,17 @@
       "resolved": "https://registry.npmjs.org/picomatch-browser/-/picomatch-browser-2.2.6.tgz",
       "integrity": "sha512-0ypsOQt9D4e3hziV8O4elD9uN0z/jtUEfxVRtNaAAtXIyUx9m/SzlO020i8YNL2aL/E6blOvvHQcin6HZlFy/w=="
     },
+    "popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "requires": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "postcss": {
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
@@ -3618,6 +3738,15 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.6.5.tgz",
       "integrity": "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw=="
+    },
+    "style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@tisoap/react-flow-smart-edge": "^3.0.0",
     "axios": "^0.26.0",
     "elkjs": "^0.8.2",
+    "framer-motion": "^6.3.3",
     "graphql": "^16.6.0",
     "graphql-request": "^5.2.0",
     "graphql-tag": "^2.12.6",

--- a/client/src/components/OptionsPanel.jsx
+++ b/client/src/components/OptionsPanel.jsx
@@ -1,22 +1,42 @@
+import {useState} from "react";
 import ReactFlow, { Panel } from "reactflow";
 import "../styles/OptionsPanel.css";
 import { ToggleSwitch } from "./ToggleSwitch";
+import { motion } from "framer-motion"
+
+
 
 export function OptionsPanel({ visualizerOptions, toggleTargetPosition }) {
   const { targetPosition } = visualizerOptions;
 
+  const [collapsed, setCollapsed] = useState(false);
+  // const [rotateIcon, setRotateIcon] = useState(false)
+  
+
+
   return (
     <>
       <Panel position="top-right" className="options-panel__container">
-        <h4 className="options-panel__header">Display Options</h4>
-        <hr className="options-panel__hr"></hr>
-        <ToggleSwitch
-          toggleName="target Position"
-          labelLeft="left"
-          labelRight="top"
-          isChecked={targetPosition === "top"}
-          handleChange={toggleTargetPosition}
-        />
+        <h4 className="options-panel__header">
+          <button className='options-panel__expand-button' onClick={() => setCollapsed(!collapsed)}>
+            Display Options <motion.div 
+              animate = {{ rotate: collapsed ? 180 : 0}}
+              id='options-panel__rotating-button'
+              >{'\u25be'}
+            </motion.div>
+          </button>
+        </h4>  
+        {!collapsed && <hr className="options-panel__hr" />}
+          {!collapsed && <div>
+            <ToggleSwitch
+              toggleName="target Position"
+              labelLeft="left"
+              labelRight="top"
+              isChecked={targetPosition === "top"}
+              handleChange={toggleTargetPosition}
+            />
+          </div>  
+          }
       </Panel>
     </>
   );

--- a/client/src/components/TypeNode.jsx
+++ b/client/src/components/TypeNode.jsx
@@ -59,6 +59,27 @@ const TypeNode = ({ data }) => {
     );
   }, [activeFieldIDs]);
 
+
+  // creating "altHandles" -- a collection of source handles with the EXACT same ID as field source handles, rendered whenever the field collapses (edges automatically snap to them)
+  const [altHandles, setAltHandles] = useState()
+  useEffect(() => {
+    setAltHandles(
+      fields.map((field) => (
+        <Handle 
+          type="source"
+          position="right"
+          id={`${typeName}/${field.fieldName}`}
+          isConnectable={false}
+          style={{position: 'absolute'}}
+        />
+      ))
+    );
+  }, []);
+      
+    
+
+  const [collapsed, setCollapsed] = useState(false)
+
   return (
     <div
       className="type-node"
@@ -79,9 +100,10 @@ const TypeNode = ({ data }) => {
           }
         />
       )}
+      {collapsed && altHandles}
       <div className="type-node__container">
-        <div style={typeHeading}>{typeName}</div>
-        <div className="type-node__fields-container">{fieldElements}</div>
+        <div onClick={() => setCollapsed(!collapsed)} style={typeHeading}>{typeName}</div>
+        {!collapsed && <div className="type-node__fields-container">{fieldElements}</div>}
       </div>
     </div>
   );

--- a/client/src/styles/OptionsPanel.css
+++ b/client/src/styles/OptionsPanel.css
@@ -2,7 +2,7 @@
   border: 1px lightgray solid;
   background-color: #fefefe;
   padding: .5rem;
-  border-radius: 3px;
+  border-radius: 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -12,6 +12,14 @@
   margin: 0;
   font-size: .8rem;
   color: #444;
+}
+
+.options-panel__expand-button {
+  background-color: transparent;
+  border: none;
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
 }
 
 .options-panel__container hr {


### PR DESCRIPTION
- Visualizer options can now be expanded or collapsed
- Individual nodes can be expanded or collapsed
- Handles spawn in the center-right of collapsed nodes to re-route edges whose source-handles have disappeared