### PR TITLE
Visualizer toggles for minimap & controls.

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,22 +5,21 @@ import Visualizer from "./components/Visualizer";
 import Split from "react-split";
 import "./styles/App.css";
 import getActivesFromQuery from "./utils/getActivesFromQuery";
-import { initialVisualizerOptions } from "./utils/initialVisualizerOptions";
 
 const App = () => {
-
   /********************************************** State & Refs *************************************************/
 
   // TODO: redux refactor (for only the necessary global pieces)
-  const [endpoint, setEndpoint] = useState("https://countries.trevorblades.com/");
+  const [endpoint, setEndpoint] = useState(
+    "https://countries.trevorblades.com/"
+  );
   const [schema, setSchema] = useState(null);
   const [vSchema, setVSchema] = useState(null);
   const [query, setQuery] = useState(null);
   const [activeTypeIDs, setActiveTypeIDs] = useState(null);
   const [activeFieldIDs, setActiveFieldIDs] = useState(null);
   const [activeEdgeIDs, setActiveEdgeIDs] = useState(null);
-  const [displayMode, setDisplayMode] = useState('all');
-  const [visualizerOptions, setVisualizerOptions] = useState(initialVisualizerOptions);
+  const [displayMode, setDisplayMode] = useState("all");
 
   /********************************************** useEFfect's *************************************************/
 
@@ -28,8 +27,9 @@ const App = () => {
   // If the user executes a query, update the active ID's for Types, Fields, & Edges
   useEffect(() => {
     if (query === null) return;
-    const {queryString} = query;
-    const { activeTypeIDs, activeFieldIDs, activeEdgeIDs } = getActivesFromQuery(queryString, vSchema);
+    const { queryString } = query;
+    const { activeTypeIDs, activeFieldIDs, activeEdgeIDs } =
+      getActivesFromQuery(queryString, vSchema);
     setActiveTypeIDs(activeTypeIDs);
     setActiveFieldIDs(activeFieldIDs);
     setActiveEdgeIDs(activeEdgeIDs);
@@ -38,10 +38,10 @@ const App = () => {
   /* Reset Actives */
   // If the schema is changed or reset, then reset all active ID's back to null
   useEffect(() => {
-    setActiveTypeIDs(null)
-    setActiveFieldIDs(null)
-    setActiveEdgeIDs(null)
-  }, [vSchema])
+    setActiveTypeIDs(null);
+    setActiveFieldIDs(null);
+    setActiveEdgeIDs(null);
+  }, [vSchema]);
 
   /************************************************ Render ******************************************************/
 
@@ -68,8 +68,6 @@ const App = () => {
             activeTypeIDs={activeTypeIDs}
             activeFieldIDs={activeFieldIDs}
             activeEdgeIDs={activeEdgeIDs}
-            visualizerOptions={visualizerOptions}
-            setVisualizerOptions={setVisualizerOptions}
             displayMode={displayMode}
             setDisplayMode={setDisplayMode}
           />

--- a/client/src/components/OptionsPanel.jsx
+++ b/client/src/components/OptionsPanel.jsx
@@ -27,7 +27,7 @@ export function OptionsPanel({
           >
             Display Options{" "}
             <motion.div
-              animate={{ rotate: collapsed ? 180 : 0 }}
+              animate={{ rotate: collapsed ? 0 : 180 }}
               id="options-panel__rotating-button"
             >
               {"\u25be"}

--- a/client/src/components/OptionsPanel.jsx
+++ b/client/src/components/OptionsPanel.jsx
@@ -1,33 +1,42 @@
-import {useState} from "react";
+import { useState } from "react";
 import { Panel } from "reactflow";
 import "../styles/OptionsPanel.css";
 import { ToggleSwitch } from "./ToggleSwitch";
-import { motion } from "framer-motion"
+import { motion } from "framer-motion";
 
-
-
-export function OptionsPanel({ visualizerOptions, toggleTargetPosition, displayMode, toggleDisplayMode }) {
-  const { targetPosition } = visualizerOptions;
+export function OptionsPanel({
+  visualizerOptions,
+  toggleTargetPosition,
+  displayMode,
+  toggleDisplayMode,
+  toggleMinimap,
+  toggleControls,
+}) {
+  const { targetPosition, showMinimap, showControls } = visualizerOptions;
 
   const [collapsed, setCollapsed] = useState(false);
   // const [rotateIcon, setRotateIcon] = useState(false)
-  
-
 
   return (
     <>
       <Panel position="top-right" className="options-panel__container">
         <h4 className="options-panel__header">
-          <button className='options-panel__expand-button' onClick={() => setCollapsed(!collapsed)}>
-            Display Options <motion.div 
-              animate = {{ rotate: collapsed ? 180 : 0}}
-              id='options-panel__rotating-button'
-              >{'\u25be'}
+          <button
+            className="options-panel__expand-button"
+            onClick={() => setCollapsed(!collapsed)}
+          >
+            Display Options{" "}
+            <motion.div
+              animate={{ rotate: collapsed ? 180 : 0 }}
+              id="options-panel__rotating-button"
+            >
+              {"\u25be"}
             </motion.div>
           </button>
-        </h4>  
+        </h4>
         {!collapsed && <hr className="options-panel__hr" />}
-          {!collapsed && <div>
+        {!collapsed && (
+          <div>
             <ToggleSwitch
               toggleName="target Position"
               labelLeft="left"
@@ -36,14 +45,28 @@ export function OptionsPanel({ visualizerOptions, toggleTargetPosition, displayM
               handleChange={toggleTargetPosition}
             />
             <ToggleSwitch
-          toggleName="Display Mode"
-          labelLeft="All"
-          labelRight="Active"
-          isChecked={displayMode === "activeOnly"}
-          handleChange={toggleDisplayMode}
-        />
-          </div>  
-          }
+              toggleName="Display Mode"
+              labelLeft="All"
+              labelRight="Active"
+              isChecked={displayMode === "activeOnly"}
+              handleChange={toggleDisplayMode}
+            />
+            <ToggleSwitch
+              toggleName="show minimap"
+              labelLeft="off"
+              labelRight="on"
+              isChecked={showMinimap}
+              handleChange={toggleMinimap}
+            />
+            <ToggleSwitch
+              toggleName="show controls"
+              labelLeft="off"
+              labelRight="on"
+              isChecked={showControls}
+              handleChange={toggleControls}
+            />
+          </div>
+        )}
       </Panel>
     </>
   );

--- a/client/src/components/Visualizer.jsx
+++ b/client/src/components/Visualizer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
@@ -16,6 +16,7 @@ import TypeNode from "./TypeNode";
 import createGraphLayout from "../utils/createGraphLayout";
 import "reactflow/dist/style.css";
 import "../styles/Visualizer.css";
+import { defaultVisualizerOptions } from "../utils/defaultVisualizerOptions";
 
 /* Custom Node */
 // Declared outside of component to prevent re-declaration upon every render
@@ -32,10 +33,7 @@ const Visualizer = ({
   activeEdgeIDs,
   displayMode,
   setDisplayMode,
-  visualizerOptions,
-  setVisualizerOptions,
 }) => {
-
   /********************************************** State & Refs *************************************************/
 
   // State management for a controlled React Flow
@@ -51,6 +49,12 @@ const Visualizer = ({
   // Ref for maintaining accurate picture of current active field ID's in listeners & callbacks
   const currentActiveFieldIDs = useRef(activeFieldIDs);
 
+  // State management for VZ options
+  const [visualizerOptions, setVisualizerOptions] = useState(
+    defaultVisualizerOptions
+  );
+  const { showControls, showMinimap } = visualizerOptions;
+
   /********************************************** useEFfect's *************************************************/
 
   /* Update Active Field ID Reference to Accurate State Upon Change */
@@ -65,26 +69,31 @@ const Visualizer = ({
     setEdges([]);
     setNodes([]);
     // Queue new node setting to explicitly occur AFTER edges & nodes reset
-    setTimeout(() => setNodes(vSchema.objectTypes.map((type) => ({
-      id: type.name,
-      // Initial positions are arbitary and will be overwritten by Elk positions.
-      // React Flow nodes need to be initialized before processed by Elk.
-      position: { x: 0, y: 0 },
-      data: {
-        typeName: type.name,
-        fields: type.fields,
-        updateEdge: (newEdge) => {
-          setEdges((prev) => [...prev, newEdge]);
-        },
-        active: false,
-        activeFieldIDs: currentActiveFieldIDs.current,
-        displayMode,
-        visualizerOptions,
-      },
-      type: `typeNode`,
-    }))), 0);
+    setTimeout(
+      () =>
+        setNodes(
+          vSchema.objectTypes.map((type) => ({
+            id: type.name,
+            // Initial positions are arbitary and will be overwritten by Elk positions.
+            // React Flow nodes need to be initialized before processed by Elk.
+            position: { x: 0, y: 0 },
+            data: {
+              typeName: type.name,
+              fields: type.fields,
+              updateEdge: (newEdge) => {
+                setEdges((prev) => [...prev, newEdge]);
+              },
+              active: false,
+              activeFieldIDs: currentActiveFieldIDs.current,
+              displayMode,
+              visualizerOptions,
+            },
+            type: `typeNode`,
+          }))
+        ),
+      0
+    );
   }, [vSchema]);
-
 
   /* Process Initial Nodes & Edges Through Elk */
   // Whenever the initialization state of the nodes changes from false to true, regraph them
@@ -97,8 +106,8 @@ const Visualizer = ({
   // Whenever the display mode or active type ID's change, update the nodes' properties to reflect the changes
   useEffect(() => {
     if (!vSchema) return;
-    setNodes(prevNodes => {
-      return prevNodes.map(node => {
+    setNodes((prevNodes) => {
+      return prevNodes.map((node) => {
         const isActive = activeTypeIDs?.has(node.id) ? true : false;
         const newNode = {
           ...node,
@@ -106,24 +115,24 @@ const Visualizer = ({
             ...node.data,
             active: isActive,
             // Always update active fields reference to avoid stale state
-            activeFieldIDs: currentActiveFieldIDs.current
+            activeFieldIDs: currentActiveFieldIDs.current,
           },
-          hidden: displayMode === 'activeOnly' && !isActive
-        }
+          hidden: displayMode === "activeOnly" && !isActive,
+        };
         return newNode;
       });
     });
     // Queue graph generation (async) to explicitly occur AFTER nodes are set
     setTimeout(() => {
-      generateGraph()
-    }, 0)
+      generateGraph();
+    }, 0);
   }, [activeTypeIDs, displayMode]);
 
   /* Update Active Edges  */
   // Whenever the display mode or active edge ID's change, update the edges' properties to reflect the changes
   useEffect(() => {
-    setEdges(prevEdges => {
-      return prevEdges.map(edge => {
+    setEdges((prevEdges) => {
+      return prevEdges.map((edge) => {
         const isActive = activeEdgeIDs?.has(edge.id) ? true : false;
         return {
           ...edge,
@@ -131,17 +140,17 @@ const Visualizer = ({
             ...edge.markerEnd,
             // TODO: refactor colors (many different paths you can take here)
             // e.g. global variables, color pickers, color schemes, dynamic color mappings
-              color: isActive ? 'magenta' : 'cornflowerblue'
+            color: isActive ? "magenta" : "cornflowerblue",
           },
           style: {
-            stroke: isActive ? 'magenta' : 'cornflowerblue',
-            strokeWidth: isActive ? '1.5' : '1.1'
+            stroke: isActive ? "magenta" : "cornflowerblue",
+            strokeWidth: isActive ? "1.5" : "1.1",
           },
           zIndex: isActive ? -1 : -2,
-          hidden: displayMode === 'activeOnly' && !isActive,
+          hidden: displayMode === "activeOnly" && !isActive,
           active: isActive,
-          animated: isActive
-        }
+          animated: isActive,
+        };
       });
     });
   }, [activeEdgeIDs, displayMode]);
@@ -159,29 +168,34 @@ const Visualizer = ({
     const { nodeInternals, edges } = store.getState();
     const currNodes = Array.from(nodeInternals.values());
     let graphedNodes, activeNodes, activeEdges;
-    if (displayMode === 'activeOnly') {
-      activeNodes = currNodes.filter(node =>  node.data.active);
-      activeEdges = edges.filter(edge => edge.active);
+    if (displayMode === "activeOnly") {
+      activeNodes = currNodes.filter((node) => node.data.active);
+      activeEdges = edges.filter((edge) => edge.active);
     }
     // Generate graph layout from React Flow nodes & edges by processing through Elk
-    if (initial || displayMode === 'all') graphedNodes = await createGraphLayout(currNodes, edges);
-    else if (displayMode === 'activeOnly') graphedNodes = await createGraphLayout(activeNodes, activeEdges);
+    if (initial || displayMode === "all")
+      graphedNodes = await createGraphLayout(currNodes, edges);
+    else if (displayMode === "activeOnly")
+      graphedNodes = await createGraphLayout(activeNodes, activeEdges);
 
     // Remap React Flow nodes to reflect the graph layout
-    if (initial) setNodes(graphedNodes) // Just map to initial state
+    if (initial) setNodes(graphedNodes); // Just map to initial state
     // Otherwise, do not overwrite existing state, but alter it accordingly
     else {
-      setNodes(prevNodes => {
-        return prevNodes.map(node => {
+      setNodes((prevNodes) => {
+        return prevNodes.map((node) => {
           // Account for dynamic shifting between display modes and permutations of active status
-          const matchingGraphedNode = graphedNodes.find(gNode => gNode.id === node.id)
+          const matchingGraphedNode = graphedNodes.find(
+            (gNode) => gNode.id === node.id
+          );
           if (matchingGraphedNode) return matchingGraphedNode;
           return node;
-        })
+        });
       });
     }
     // Queue fitView to explicitly occur AFTER the graphed nodes have asynchronously been set
-    if (displayMode === 'activeOnly' || initial) setTimeout(() => flowInstance.fitView(), 0);
+    if (displayMode === "activeOnly" || initial)
+      setTimeout(() => flowInstance.fitView(), 0);
     // You can configure this to fitView after every change when displayMode === 'all' as well,
     // however that UX feels slightly worse
   };
@@ -190,15 +204,15 @@ const Visualizer = ({
   function toggleTargetPosition() {
     const targetPosition =
       visualizerOptions.targetPosition === "left" ? "top" : "left";
-    const newTargetPosition = { targetPosition };
-    setVisualizerOptions(newTargetPosition);
+    const updatedVisualizerOptions = { ...visualizerOptions, targetPosition };
+    setVisualizerOptions(updatedVisualizerOptions);
     setNodes((nodes) =>
       nodes.map((node) => {
         const updatedNode = {
           ...node,
           data: {
             ...node.data,
-            visualizerOptions: newTargetPosition,
+            visualizerOptions: updatedVisualizerOptions,
           },
         };
         updateNodeInternals(updatedNode.id);
@@ -209,7 +223,25 @@ const Visualizer = ({
 
   /* Toggle Display Mode */
   function toggleDisplayMode() {
-    setDisplayMode(prevDisplayMode => prevDisplayMode === 'activeOnly' ? 'all' : 'activeOnly');
+    setDisplayMode((prevDisplayMode) =>
+      prevDisplayMode === "activeOnly" ? "all" : "activeOnly"
+    );
+  }
+
+  // /* Toggle Minimap */
+  function toggleMinimap() {
+    const showMinimap = !visualizerOptions.showMinimap;
+    const updatedVisualizerOptions = { ...visualizerOptions, showMinimap };
+    setVisualizerOptions(updatedVisualizerOptions);
+    return updatedNode;
+  }
+
+  // /* Toggle Controls */
+  function toggleControls() {
+    const showControls = !visualizerOptions.showControls;
+    const updatedVisualizerOptions = { ...visualizerOptions, showControls };
+    setVisualizerOptions(updatedVisualizerOptions);
+    return updatedNode;
   }
 
   /************************************************ Render ******************************************************/
@@ -235,10 +267,12 @@ const Visualizer = ({
           toggleTargetPosition={toggleTargetPosition}
           displayMode={displayMode}
           toggleDisplayMode={toggleDisplayMode}
+          toggleMinimap={toggleMinimap}
+          toggleControls={toggleControls}
         />
         <Background />
-        <Controls />
-        <MiniMap />
+        {showControls && <Controls />}
+        {showMinimap && <MiniMap />}
       </ReactFlow>
     </div>
   );

--- a/client/src/styles/OptionsPanel.css
+++ b/client/src/styles/OptionsPanel.css
@@ -23,6 +23,16 @@
   flex-direction: row;
   gap: 10px;
 }
+.options-panel__expand-button::after{
+  content: '';
+  border: 1px rgba(0, 0, 0, .8)  solid;
+  background-color: rgba(0, 0, 0, 0.1); ;
+  height: 17px;
+  width: 17px;
+  position: absolute;
+  right: 10px;
+  border-radius: 50%;
+}
 
 .options-panel__container hr {
   width: 100%;

--- a/client/src/utils/defaultVisualizerOptions.js
+++ b/client/src/utils/defaultVisualizerOptions.js
@@ -1,0 +1,5 @@
+export const defaultVisualizerOptions = {
+  targetPosition: "left", // valid values: 'left' || 'top'
+  showMinimap: true,
+  showControls: true,
+};

--- a/client/src/utils/initialVisualizerOptions.js
+++ b/client/src/utils/initialVisualizerOptions.js
@@ -1,3 +1,0 @@
-export const initialVisualizerOptions = {
-  targetPosition: "left", // valid values: 'left' || 'top'
-};


### PR DESCRIPTION
- moved visualizerOptions state from App.jsx into Visualizer.jsx to eliminate prop drilling
- renamed initialVisualizerOptions to defaultVisualizerOptions.
- added showMiniMap and showControls properties to defaultVisualizerOptions
- added toggle capability for <Minimap /> and <Controls />
- added CSS :after pseudo-class to frame the framer-motions arrow and act like a button

TO DO: refactor toggles to be more DRY