### PR TITLE
Implemented collapse/expand all functionality, made minor changes

### DIFF
--- a/client/src/components/OptionsPanel.jsx
+++ b/client/src/components/OptionsPanel.jsx
@@ -4,6 +4,7 @@ import "../styles/OptionsPanel.css";
 import { ToggleSwitch } from "./ToggleSwitch";
 import { ColorPicker } from "./ColorPicker";
 import { motion } from "framer-motion";
+import { Pushbutton } from "./Pushbutton";
 
 export function OptionsPanel({
   visualizerOptions,
@@ -16,6 +17,8 @@ export function OptionsPanel({
   setCustomColors,
   ghostMode,
   toggleGhostMode,
+  collapseAll,
+  expandAll,
 }) {
   const { targetPosition, showMinimap, showControls } = visualizerOptions;
 
@@ -49,20 +52,7 @@ export function OptionsPanel({
               isChecked={targetPosition === "top"}
               handleChange={toggleTargetPosition}
             />
-            <ToggleSwitch
-              toggleName="Active Only"
-              labelLeft="Off"
-              labelRight="On"
-              isChecked={displayMode === "activeOnly"}
-              handleChange={toggleDisplayMode}
-            />
-            <ToggleSwitch
-              toggleName="Ghost Mode"
-              labelLeft="off"
-              labelRight="on"
-              isChecked={ghostMode === "on"}
-              handleChange={toggleGhostMode}
-            />
+            
             <ToggleSwitch
               toggleName="show minimap"
               labelLeft="off"
@@ -102,6 +92,29 @@ export function OptionsPanel({
               target="edgeHighlight"
               defaultColor={customColors}
             />
+            <Pushbutton
+              buttonText="Expand All"
+              handleClick={expandAll}
+            />
+            <Pushbutton
+              buttonText="Collapse All"
+              handleClick={collapseAll}
+            />
+            <ToggleSwitch
+              toggleName="Active Only"
+              labelLeft="Off"
+              labelRight="On"
+              isChecked={displayMode === "activeOnly"}
+              handleChange={toggleDisplayMode}
+            />
+            {displayMode === "activeOnly" &&
+            <ToggleSwitch
+              toggleName="Ghost Mode"
+              labelLeft="off"
+              labelRight="on"
+              isChecked={ghostMode === "on"}
+              handleChange={toggleGhostMode}
+            />}
           </div>
         )}
       </Panel>

--- a/client/src/components/Pushbutton.jsx
+++ b/client/src/components/Pushbutton.jsx
@@ -1,0 +1,12 @@
+import "../styles/Pushbutton.css";
+
+export function Pushbutton({
+  buttonText,
+  handleClick
+}) {
+  return(
+    <div className="Pushbutton">
+      <button onClick={() => {handleClick()}}>{buttonText}</button>
+    </div>
+  );
+}

--- a/client/src/components/TypeNode.jsx
+++ b/client/src/components/TypeNode.jsx
@@ -14,6 +14,8 @@ const TypeNode = ({ data }) => {
     visualizerOptions,
     customColors,
     isGhost,
+    collapseTrigger,
+    expandTrigger,
   } = data;
   const [fieldElements, setFieldElements] = useState();
 
@@ -41,6 +43,7 @@ const TypeNode = ({ data }) => {
             activeFieldIDs?.has(`${typeName}/${field.fieldName}`) ? true : false
           }
           displayMode={displayMode}
+          
         />
       ))
     );
@@ -63,6 +66,16 @@ const TypeNode = ({ data }) => {
   }, []);
 
   const [collapsed, setCollapsed] = useState(false);
+  
+  const forceCollapse = () => {
+    if(!collapsed) setCollapsed(true)
+  }
+  const forceUncollapse = () => {
+    if(collapsed) setCollapsed(false)
+  }
+
+  useEffect(() => {if(collapseTrigger  > 0) forceCollapse()}, [collapseTrigger])
+  useEffect(() => {if(expandTrigger > 0) forceUncollapse()}, [expandTrigger])
 
   return (
     <div className={`type-node ${active ? "gradient-border2" : ""}`}>
@@ -72,6 +85,7 @@ const TypeNode = ({ data }) => {
           position={targetPosition === "left" ? "left" : "top"}
           id={typeName}
           isConnectable={false}
+          
           className={
             targetPosition === "left"
               ? "type-node__handle-target-left"

--- a/client/src/components/Visualizer.jsx
+++ b/client/src/components/Visualizer.jsx
@@ -64,6 +64,10 @@ const Visualizer = ({
   );
   const { showControls, showMinimap } = visualizerOptions;
 
+  //Triggers for "Expand All" and "Collapse All" functionality
+  const [collapseTrigger, setCollapseTrigger] = useState(0)
+  const [expandTrigger, setExpandTrigger] = useState(0)
+
   /********************************************** useEFfect's *************************************************/
 
   /* Update Active Field ID Reference to Accurate State Upon Change */
@@ -93,11 +97,19 @@ const Visualizer = ({
                 setEdges((prev) => [...prev, newEdge]);
               },
               active: false,
+              markerEnd: {
+                type: MarkerType.ArrowClosed,
+                width: 28,
+                height: 28,
+                strokeWidth: 0.7,
+              },
               isGhost: false,
               activeFieldIDs: currentActiveFieldIDs.current,
               ghostNodeIDs: displayMode,
               visualizerOptions,
               customColors: customColors,
+              collapseTrigger: 0,
+              expandTrigger: 0,
             },
             type: `typeNode`,
           }))
@@ -135,6 +147,8 @@ const Visualizer = ({
             ...node.data,
             active: isActive,
             isGhost: isGhost,
+            collapseTrigger: collapseTrigger,
+            expandTrigger: expandTrigger,
             // Always update active fields reference to avoid stale state
             activeFieldIDs: currentActiveFieldIDs.current,
           },
@@ -147,7 +161,7 @@ const Visualizer = ({
     setTimeout(() => {
       generateGraph();
     }, 0);
-  }, [activeTypeIDs, displayMode, ghostNodeIDs, ghostMode]);
+  }, [activeTypeIDs, displayMode, ghostNodeIDs, ghostMode, collapseTrigger, expandTrigger]);
 
   /* Update Active Edges  */
   // Whenever the display mode or active edge ID's change, update the edges' properties to reflect the changes
@@ -190,6 +204,8 @@ const Visualizer = ({
           active: isActive,
           animated: isActive,
           isGhost: isGhost,
+          collapseTrigger: collapseTrigger,
+          expandTrigger: expandTrigger,
         };
         return newEdge;
       });
@@ -320,6 +336,16 @@ const Visualizer = ({
     // return "rgba(188, 183, 204, .5)";
   };
 
+  // /* Collapsing and expanding all nodes */
+  const collapseAll = () => {setCollapseTrigger((collapseTrigger) => collapseTrigger + 1)}
+  const expandAll = () => {setExpandTrigger((expandTrigger) => expandTrigger + 1)}
+
+  // /* Resetting the trigger for collapsing nodes to prevent buggy functionality when changing Display Mode */
+  useEffect(() => {
+    setCollapseTrigger(0)
+    setExpandTrigger(0)
+  }, [displayMode, ghostMode]);
+
   function updateColors(colorCode, colorTarget) {
     const currentColors = customColors;
     currentColors[colorTarget] = colorCode;
@@ -344,6 +370,7 @@ const Visualizer = ({
         const updatedEdge = {
           ...edge,
           markerEnd: {
+            type: MarkerType.ArrowClosed,
             width: edge.active ? 18 : 28,
             height: edge.active ? 18 : 28,
             strokeWidth: edge.active ? 0.6 : 0.7,
@@ -363,6 +390,8 @@ const Visualizer = ({
     );
   }
 
+  
+  
   /************************************************ Render ******************************************************/
 
   return (
@@ -383,7 +412,7 @@ const Visualizer = ({
         zoom={1}
         proOptions={{ hideAttribution: true }}
       >
-        <Background variant={"dots"} size={1.5} gap={55} color={"#a28a8a"} />
+        <Background variant={"dots"} size={1.5} gap={55} color={"#a28a8a"}/>
         <OptionsPanel
           visualizerOptions={visualizerOptions}
           toggleTargetPosition={toggleTargetPosition}
@@ -395,6 +424,8 @@ const Visualizer = ({
           setCustomColors={updateColors}
           ghostMode={ghostMode}
           toggleGhostMode={toggleGhostMode}
+          collapseAll={collapseAll}
+          expandAll={expandAll}
         />
         <Background />
         {showControls && <Controls />}

--- a/client/src/styles/Pushbutton.css
+++ b/client/src/styles/Pushbutton.css
@@ -1,0 +1,20 @@
+.Pushbutton{
+  background: none;
+  border: none;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  opacity: 75%;
+}
+.Pushbutton button{
+  background: transparent;
+  color: #F5F5F5;
+  border: 1px groove #F5F5F5;
+  
+  font-size: 12px;
+  font-weight: 400;
+  border-radius: 5px;
+  margin: 5px;
+  
+}


### PR DESCRIPTION
Updates Include:
- Collapse/Expand all buttons added
- "Ghost Mode" Toggle only appears on active-only 
- Edge arrows persist, and color changes to match edges

Potential Issues:
- Collapse/Expand all buttons trigger re-mapping *sometimes*, but not every time, leading to potentially awkward node formatting. They should re-map every time (optimal) or never.
- "Active Only" moved to bottom of Options Panel. In the future, we will implement something like React Framer-Motion to allow the Ghost Mode Div to appear gradually. As it stands, it appears abruptly, triggering a jarring re-render of everything *below* it. Therefore, it's moved to the bottom, with "Active Only" right above it, which, although suboptimal from a design perspective, is better for functionality. 